### PR TITLE
Use 1970 instead of 70 for timelocal

### DIFF
--- a/entries_kache
+++ b/entries_kache
@@ -310,7 +310,7 @@ sub parsedate {
 	$mi = $5 || 0;
 	$s  = $6 || 0;
 	if (!$8) {
-		$z = 0 - timelocal(0, 0, 0, 1, 0, 70);
+		$z = 0 - timelocal(0, 0, 0, 1, 0, 1970);
 	} elsif ($8 eq 'Z') {
 		$z = 0;
 	} else {
@@ -329,7 +329,7 @@ sub parsedate {
 
 sub datestring {
 	my $time = $_[0];
-	my $z = 0 - timelocal(0, 0, 0, 1, 0, 70);
+	my $z = 0 - timelocal(0, 0, 0, 1, 0, 1970);
 	my $zh = $z / 3600;
 	my $zm = (abs($z) % 3600) / 60;
 	# $zh, $zmの小数部は、後のsprintfにより切り捨てられる。


### PR DESCRIPTION
```
$ perl -MTime::Local -e 'print -timelocal(0, 0, 0, 1, 0, 70) / 3600'
-876591

$ perl -MTime::Local -e 'print -timelocal(0, 0, 0, 1, 0, 1970) / 3600'
9
```

It is related to this code of Time::Local.

https://github.com/Perl/perl5/blob/blead/cpan/Time-Local/lib/Time/Local.pm#L19-L22



